### PR TITLE
Fix environment in content scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Helps you work on TeamDynamix tickets more efficiently.",
   "main": "index.ts",
   "scripts": {
-    "build": "vite build && vite-node buildContentScripts.ts",
+    "build": "vite build && NODE_ENV=production vite-node buildContentScripts.ts",
     "build-dev": "NODE_ENV=development vite build -m development && NODE_ENV=development vite-node buildContentScripts.ts",
     "dev": "rm -rf tmp/contentScripts && cp -r build/scripts/contentScripts/. tmp/contentScripts && NODE_ENV=development vite build -m development && cp -r tmp/contentScripts build/scripts/contentScripts",
     "clean": "rm -rf ./build && rm -rf tmp/contentScripts",

--- a/src/utils/rules/hotkeyRules.ts
+++ b/src/utils/rules/hotkeyRules.ts
@@ -80,11 +80,11 @@ export const hotkeyRules: Record<string, () => void> = {
 		// Assign (reassign/escalate)
 		const reassignButton = document.querySelector("#divReassignTicket");
 		if (reassignButton === null || !(reassignButton instanceof HTMLElement)) {
-			log.e("Failed to scroll to top of feed section");
-			return;
-		} else {
+			log.e("Failed to locate reassign button");
 			// fallback
 			window.open(`${TICKETS_BASE_URL}/TicketReassign?TicketID=${getCurrentTicketNumber()}`, "TicketAssign564440", "popup=1,width=992,height=700,left=459,top=160");
+		} else {
+			reassignButton.click();
 		}
 	},
 };


### PR DESCRIPTION
Content scripts think that they are always getting `process.env.NODE_ENV == "development"`.

For #37 